### PR TITLE
Allow ff-share to use same object in updates

### DIFF
--- a/src/dynamic-fragment.js
+++ b/src/dynamic-fragment.js
@@ -276,12 +276,13 @@ function updateNativeElement(element, newValue) {
 			}
 			break
 		case 'checkbox':
+			const elementCheckedValue = element.value && element.value != 'on' ? element.value : element.name
 			if (typeof newValue == 'boolean') {
 				element.checked = newValue
 			} else if (newValue instanceof Set) {
-				element.checked = newValue.has(element.name)
+				element.checked = newValue.has(elementCheckedValue)
 			} else if (Array.isArray(newValue)) {
-				element.checked = newValue.includes(element.name)
+				element.checked = newValue.includes(elementCheckedValue)
 			} else {
 				console.warn('Unexpected type for checkbox input', newValue)
 			}
@@ -696,19 +697,20 @@ export class DynamicFragment {
 
 		switch (element.type) {
 			case 'checkbox':
+				const elementCheckedValue = element.value && element.value != 'on' ? element.value : element.name
 				if (isTwowayBinding(binding)) { // Update the binding
 					const valueBefore = binding.get()
 					if (valueBefore instanceof Set) {
 						const newSet = new Set(valueBefore)
 						element.checked ?
-							newSet.add(element.name) :
-							newSet.delete(element.name)
+							newSet.add(elementCheckedValue) :
+							newSet.delete(elementCheckedValue)
 						return binding.set(newSet, event)
 					}
 					if (valueBefore instanceof Array) {
-						const indexBefore = valueBefore.indexOf(element.name)
+						const indexBefore = valueBefore.indexOf(elementCheckedValue)
 						const newArrayValue = element.checked ?
-							valueBefore.concat(element.name) :
+							valueBefore.concat(elementCheckedValue) :
 							valueBefore.toSpliced(indexBefore, 1)
 						return binding.set(newArrayValue, event)
 					}
@@ -716,11 +718,13 @@ export class DynamicFragment {
 
 				} else if (binding instanceof Set) {
 					// mutate the set directly
-					element.checked ? binding.add(element.name) : binding.delete(element.name)
+					element.checked ? binding.add(elementCheckedValue) : binding.delete(elementCheckedValue)
 				} else if (isArrayOfStrings(binding)) {
-					if (element.checked && !binding.includes(element.name)) binding.push(element.name)
+					if (element.checked && !binding.includes(elementCheckedValue))
+						binding.push(elementCheckedValue)
 
-					if (!element.checked && binding.includes(element.name)) binding.splice(binding.indexOf(element.name), 1)
+					if (!element.checked && binding.includes(elementCheckedValue))
+						binding.splice(binding.indexOf(elementCheckedValue), 1)
 
 				} else throw new Error('Invalid state binding for checkbox')
 				break

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,3 +26,17 @@ export function addTestContainer(id = 'elements-render-here') {
 export function property(key, value) {
 	return new PropertySetter(key, value)
 }
+
+/**
+ * @param {string} text
+ */
+export function normalizeMarkupText(text) {
+	return text.replaceAll(/\s+/g, ' ').trim()
+}
+
+/**
+ * @param {HTMLElement} element
+ */
+export function shadowText(element) {
+	return normalizeMarkupText(element.shadowRoot?.textContent ?? '')
+}

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2,22 +2,9 @@ import { before, describe, it } from '@applicvision/js-toolbox/test'
 import expect from '@applicvision/js-toolbox/expect'
 import { DeclarativeElement } from '../src/declarative-element.js'
 import { html, twoway } from '../src/dynamic-fragment.js'
-import { addTestContainer } from './helpers.js'
+import { addTestContainer, normalizeMarkupText, shadowText } from './helpers.js'
 import { island } from '../src/dynamic-island.js'
 
-/**
- * @param {HTMLElement} element
- */
-function shadowText(element) {
-	return normalizeMarkupText(element.shadowRoot?.textContent ?? '')
-}
-
-/**
- * @param {string} text
- */
-function normalizeMarkupText(text) {
-	return text.replaceAll(/\s+/g, ' ').trim()
-}
 
 /**
  * @param {HTMLElement} element
@@ -53,11 +40,6 @@ describe('Stateful component', () => {
 
 	class Alternating extends DeclarativeElement {
 		state = this.reactive({ loading: true })
-
-		// Expose the protected method
-		sharedStateChanged() {
-			super.sharedStateChanged()
-		}
 
 		render() {
 			if (this.state.loading) {


### PR DESCRIPTION
By allowing the shared object to be reused, there is no need to recreate object to get updates in the fragment.
For instance, when working with a `<select multiple>`, an ff-shared array can be manipulated and the render function can just pass that same array to the fragment, and get appropriate updates to the select element's state.